### PR TITLE
Fix TypeScript @ts-ignore comments for media interfaces

### DIFF
--- a/app/app/room/[id].tsx
+++ b/app/app/room/[id].tsx
@@ -473,13 +473,10 @@ export default function RoomScreen() {
         // Quick test of permissions - just check if permissions are accessible
         try {
           console.log('[Room] Requesting permission status...');
-          // @ts-ignore - Permissions API may not be available in all browsers
           if (navigator.permissions?.query) {
-            // @ts-ignore
             const cameraPermission = await navigator.permissions.query({ name: 'camera' });
             console.log('[Room] Camera permission status:', cameraPermission.state);
 
-            // @ts-ignore
             const micPermission = await navigator.permissions.query({ name: 'microphone' });
             console.log('[Room] Microphone permission status:', micPermission.state);
 

--- a/app/services/media.ts
+++ b/app/services/media.ts
@@ -401,11 +401,9 @@ export class MediaManager {
       logger.info(`Switching audio output device to ${deviceId}`);
 
       // Check if setSinkId is supported
-      // @ts-ignore: setSinkId may not be available in all browsers
       if (element.setSinkId) {
         logger.debug('setSinkId is supported, setting output device');
         try {
-          // @ts-ignore
           await element.setSinkId(deviceId);
           this.currentAudioOutputDevice = deviceId;
           logger.info('Audio output device switched successfully');
@@ -428,7 +426,6 @@ export class MediaManager {
    * Check if setSinkId is supported by the browser
    */
   public isSinkIdSupported(element: HTMLMediaElement): boolean {
-    // @ts-ignore: setSinkId may not be available in all browsers
     return typeof element.setSinkId === 'function';
   }
 
@@ -596,13 +593,11 @@ export class MediaManager {
       logger.info('Requesting screen sharing');
 
       // Check if getDisplayMedia is available
-      // @ts-ignore: TypeScript doesn't recognize getDisplayMedia on mediaDevices
       if (!navigator.mediaDevices || !navigator.mediaDevices.getDisplayMedia) {
         logger.error('getDisplayMedia is not supported in this browser');
         return null;
       }
 
-      // @ts-ignore: TypeScript doesn't recognize getDisplayMedia on mediaDevices
       const stream = await navigator.mediaDevices.getDisplayMedia({ video: true });
 
       logger.info('Screen sharing access granted');
@@ -638,7 +633,6 @@ export class MediaManager {
    * Check if the browser supports getDisplayMedia for screen sharing
    */
   public isScreenShareSupported(): boolean {
-    // @ts-ignore: TypeScript doesn't recognize getDisplayMedia on mediaDevices
     return !!navigator.mediaDevices?.getDisplayMedia;
   }
 }

--- a/app/types/augmentations.d.ts
+++ b/app/types/augmentations.d.ts
@@ -1,0 +1,71 @@
+/**
+ * TypeScript type augmentations for experimental browser APIs
+ * This file provides proper type definitions for APIs that are experimental
+ * or not yet fully supported in the TypeScript standard lib.dom.d.ts
+ */
+
+// Extend HTMLMediaElement with setSinkId method from Audio Output Devices API
+interface HTMLMediaElement {
+  /**
+   * Sets the ID of the audio device to use for output.
+   * This is an experimental feature part of the Audio Output Devices API.
+   * @param deviceId - The ID of the audio output device.
+   * @returns A Promise that resolves when the operation completes.
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/setSinkId
+   */
+  setSinkId?(deviceId: string): Promise<void>;
+}
+
+// Extend MediaDevices with getDisplayMedia method for screen sharing
+interface MediaDevices {
+  /**
+   * Prompts the user to select a display or portion of a display to capture 
+   * as a MediaStream for screen sharing.
+   * @param constraints - The media constraints for the stream to obtain.
+   * @returns A Promise that resolves to a MediaStream object.
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia
+   */
+  getDisplayMedia(constraints?: MediaStreamConstraints): Promise<MediaStream>;
+}
+
+// Extend Navigator with Permissions API
+interface NavigatorPermissions {
+  /**
+   * Permissions API interface for querying permission states.
+   */
+  permissions?: {
+    /**
+     * Queries the status of a permission for the current origin.
+     * @param permissionDesc - The permission descriptor to query.
+     * @returns A Promise that resolves to a PermissionStatus object.
+     */
+    query(permissionDesc: PermissionDescriptor): Promise<PermissionStatus>;
+  };
+}
+
+// Extend Navigator interface with permissions
+interface Navigator extends NavigatorPermissions {}
+
+// Define PermissionDescriptor for media permissions
+interface PermissionDescriptor {
+  /**
+   * The permission name to query.
+   * For media permissions, this would be 'camera', 'microphone', etc.
+   */
+  name: 'camera' | 'microphone' | 'speaker' | string;
+}
+
+// Define PermissionStatus type
+interface PermissionStatus {
+  /**
+   * The current state of the permission.
+   * 'granted' - The permission is allowed.
+   * 'denied' - The permission is denied.
+   * 'prompt' - The user will be prompted for permission.
+   */
+  state: 'granted' | 'denied' | 'prompt';
+  /**
+   * Fired when the status of the permission changes.
+   */
+  onchange: ((this: PermissionStatus, ev: Event) => any) | null;
+}

--- a/app/types/augmentations.d.ts
+++ b/app/types/augmentations.d.ts
@@ -19,7 +19,7 @@ interface HTMLMediaElement {
 // Extend MediaDevices with getDisplayMedia method for screen sharing
 interface MediaDevices {
   /**
-   * Prompts the user to select a display or portion of a display to capture 
+   * Prompts the user to select a display or portion of a display to capture
    * as a MediaStream for screen sharing.
    * @param constraints - The media constraints for the stream to obtain.
    * @returns A Promise that resolves to a MediaStream object.


### PR DESCRIPTION
## Summary
- Created a new type definitions file (`augmentations.d.ts`) for experimental browser APIs
- Added proper TypeScript definitions for:
  - `setSinkId` on HTMLMediaElement
  - `getDisplayMedia` on MediaDevices
  - Permissions API
- Removed all @ts-ignore comments from `media.ts` and `[id].tsx`
- Verified all tests pass with the new type definitions

## Test plan
- [x] Run TypeScript type check (`npm run typecheck`)
- [x] Run media manager tests (`npm test -- --testPathPattern="/__tests__/services/media.test.ts$"`)
- [x] Run component tests to verify changes don't break UI

Fixes #14

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced media functionality for a smoother experience with camera, microphone permissions, screen sharing, and audio output control.
- **Refactor**
  - Improved internal reliability by removing legacy workarounds, ensuring stricter checks and better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->