### PR TITLE
Group Signaling Messages by Connection ID

### DIFF
--- a/app/hooks/useSignaling.ts
+++ b/app/hooks/useSignaling.ts
@@ -187,14 +187,14 @@ export function useSignaling(
 
   // Send a message
   const sendMessage = useCallback(
-    async (type: string, data: any, recipient?: string) => {
+    async (type: string, data: any, recipient?: string, forceRoomId?: string, forceSenderId?: string, extraFields?: Record<string, any>) => {
       if (!signalingServiceRef.current || !connected) {
         logger.warn('Cannot send message: Not connected to room');
         return false;
       }
 
       try {
-        await signalingServiceRef.current.sendMessage(type, data, recipient);
+        await signalingServiceRef.current.sendMessage(type, data, recipient, forceRoomId, forceSenderId, extraFields);
         return true;
       } catch (error) {
         logger.error('Error sending message:', error);

--- a/app/hooks/useWebRTC.ts
+++ b/app/hooks/useWebRTC.ts
@@ -79,16 +79,19 @@ export function useWebRTC(localStream: MediaStream | null, options: UseWebRTCOpt
 
   // Process an incoming WebRTC offer
   const processOffer = useCallback(
-    async (offer: RTCSessionDescriptionInit) => {
+    async (offer: RTCSessionDescriptionInit, connectionId: string) => {
       if (!webrtcManagerRef.current || !isInitialized) {
         logger.warn('Cannot process offer: WebRTC not initialized');
         return null;
       }
 
       try {
-        logger.info('Processing WebRTC offer');
-        const answer = await webrtcManagerRef.current.processOffer(offer);
-        return answer;
+        logger.info('Processing WebRTC offer with connection ID:', connectionId);
+        const result = await webrtcManagerRef.current.processOffer(offer, connectionId);
+        return { 
+          answer: result.answer, 
+          connectionId: result.connectionId 
+        };
       } catch (error) {
         logger.error('Error processing offer:', error);
         return null;
@@ -99,15 +102,15 @@ export function useWebRTC(localStream: MediaStream | null, options: UseWebRTCOpt
 
   // Process an incoming WebRTC answer
   const processAnswer = useCallback(
-    async (answer: RTCSessionDescriptionInit) => {
+    async (answer: RTCSessionDescriptionInit, connectionId: string) => {
       if (!webrtcManagerRef.current || !isInitialized) {
         logger.warn('Cannot process answer: WebRTC not initialized');
         return false;
       }
 
       try {
-        logger.info('Processing WebRTC answer');
-        await webrtcManagerRef.current.processAnswer(answer);
+        logger.info('Processing WebRTC answer with connection ID:', connectionId);
+        await webrtcManagerRef.current.processAnswer(answer, connectionId);
         return true;
       } catch (error) {
         logger.error('Error processing answer:', error);
@@ -126,8 +129,11 @@ export function useWebRTC(localStream: MediaStream | null, options: UseWebRTCOpt
 
     try {
       logger.info('Creating WebRTC offer');
-      const offer = await webrtcManagerRef.current.createOffer();
-      return offer;
+      const result = await webrtcManagerRef.current.createOffer();
+      return { 
+        offer: result.offer, 
+        connectionId: result.connectionId 
+      };
     } catch (error) {
       logger.error('Error creating offer:', error);
       return null;
@@ -136,17 +142,17 @@ export function useWebRTC(localStream: MediaStream | null, options: UseWebRTCOpt
 
   // Add an ICE candidate from a peer
   const addIceCandidate = useCallback(
-    async (candidate: RTCIceCandidateInit) => {
+    async (candidate: RTCIceCandidateInit, connectionId: string) => {
       if (!webrtcManagerRef.current || !isInitialized) {
         logger.warn('Cannot add ICE candidate: WebRTC not initialized');
         return false;
       }
 
       try {
-        logger.info('Adding ICE candidate');
+        logger.info('Adding ICE candidate with connection ID:', connectionId);
         // Create a proper RTCIceCandidate object
         const iceCandidate = new RTCIceCandidate(candidate);
-        await webrtcManagerRef.current.addIceCandidate(iceCandidate);
+        await webrtcManagerRef.current.addIceCandidate(iceCandidate, connectionId);
         return true;
       } catch (error) {
         logger.error('Error adding ICE candidate:', error);
@@ -158,7 +164,7 @@ export function useWebRTC(localStream: MediaStream | null, options: UseWebRTCOpt
 
   // Set ice candidate handler
   const setOnIceCandidate = useCallback(
-    (handler: (candidate: RTCIceCandidateInit) => void) => {
+    (handler: (candidate: RTCIceCandidateInit, connectionId: string) => void) => {
       if (!webrtcManagerRef.current) {
         logger.warn('Cannot set ICE candidate handler: WebRTC not initialized');
         return false;

--- a/app/services/signaling.ts
+++ b/app/services/signaling.ts
@@ -13,6 +13,7 @@ export interface SignalingMessage {
   roomId: string;
   data: any;
   timestamp?: number; // Add timestamp property
+  connectionId?: string; // Unique ID to group related WebRTC signaling messages
 }
 
 export class SignalingService {
@@ -93,7 +94,8 @@ export class SignalingService {
     data: any,
     receiver?: string,
     forceRoomId?: string,
-    forceSenderId?: string
+    forceSenderId?: string,
+    extraFields?: Record<string, any>
   ): Promise<void> {
     // Allow force sending with specific room and user IDs (used when leaving a room)
     const roomId = forceRoomId || this.roomId;
@@ -114,6 +116,19 @@ export class SignalingService {
 
     if (receiver) {
       message.receiver = receiver;
+    }
+    
+    // Add any extra fields to the message (like connectionId)
+    if (extraFields) {
+      Object.entries(extraFields).forEach(([key, value]) => {
+        // @ts-ignore: We're intentionally adding dynamic properties from extraFields
+        message[key] = value;
+      });
+      
+      // Log if there's a connection ID (useful for WebRTC debugging)
+      if (extraFields.connectionId) {
+        this.logger.info(`Sending message with connection ID: ${extraFields.connectionId}`);
+      }
     }
 
     try {


### PR DESCRIPTION
## Summary
- Added connection ID tracking to WebRTC signaling to properly match offers, answers, and ICE candidates
- Modified WebRTC manager and hooks to generate, track, and verify connection IDs
- Updated signaling code to handle connection IDs for all WebRTC messages
- Fixed tests to support the new connection ID parameter

## Test plan
- Test video call with two or more participants to verify proper connection handling
- Test reconnection scenarios to ensure new connection IDs are generated
- Verify backward compatibility with clients that don't send connection IDs

Fixes #45

🤖 Generated with [Claude Code](https://claude.ai/code)